### PR TITLE
Adding support/tests for textShadow and Offset components.

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -77,6 +77,8 @@ function autoload679875ef60343fd604aa0fa4d353e67e($class) {
             'chapterthree\\applenewsapi\\document\\styles\\fills\\imagefill' => '/src/Document/Styles/Fills/ImageFill.php',
             'chapterthree\\applenewsapi\\document\\styles\\fills\\videofill' => '/src/Document/Styles/Fills/VideoFill.php',
             'chapterthree\\applenewsapi\\document\\styles\\inlinetextstyle' => '/src/Document/Styles/InlineTextStyle.php',
+            'chapterthree\\applenewsapi\\document\\styles\\offset' => '/src/Document/Styles/Offset.php',
+            'chapterthree\\applenewsapi\\document\\styles\\shadowstyle' => '/src/Document/Styles/ShadowStyle.php',
             'chapterthree\\applenewsapi\\document\\styles\\strokestyle' => '/src/Document/Styles/StrokeStyle.php',
             'chapterthree\\applenewsapi\\document\\styles\\textstrokestyle' => '/src/Document/Styles/TextStrokeStyle.php',
             'chapterthree\\applenewsapi\\document\\styles\\textstyle' => '/src/Document/Styles/TextStyle.php',

--- a/src/Document/Styles/Offset.php
+++ b/src/Document/Styles/Offset.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @file
+ * An Apple News component offset.
+ */
+
+namespace ChapterThree\AppleNewsAPI\Document\Styles;
+
+use ChapterThree\AppleNewsAPI\Document\Base;
+
+/**
+ * An Apple News Offset component.
+ */
+class Offset extends Base {
+
+  /**
+   * X coordinate
+   *
+   * @var float
+   */
+  protected $x;
+
+  /**
+   * Y coordinate
+   *
+   * @var float
+   */
+  protected $y;
+
+  /**
+   * Gets x
+   *
+   * @return float
+   */
+  public function getX() {
+    return $this->x;
+  }
+
+  /**
+   * Sets x
+   *
+   * @param float $x
+   */
+  public function setX($x) {
+    if ($this->validateOffset($x)) {
+      $this->x = round($x, 1);
+    }
+  }
+
+  /**
+   * Gets y
+   *
+   * @return float
+   */
+  public function getY() {
+    return $this->y;
+  }
+
+  /**
+   * Sets y
+   *
+   * @param float $y
+   */
+  public function setY($y) {
+    if ($this->validateOffset($y)) {
+      $this->y = round($y, 1);
+    }
+  }
+
+  /**
+   * Validates the offset.
+   *
+   * @param mixed $value
+   *
+   * @return bool
+   */
+  protected function validateOffset($value) {
+    return is_numeric($value) && $value > -50 && $value < 50;
+  }
+}

--- a/src/Document/Styles/Offset.php
+++ b/src/Document/Styles/Offset.php
@@ -90,6 +90,6 @@ class Offset extends Base {
    * @return bool
    */
   protected function validateOffset($value) {
-    return is_numeric($value) && $value > -50 && $value < 50;
+    return is_numeric($value) && $value >= -50 && $value <= 50;
   }
 }

--- a/src/Document/Styles/Offset.php
+++ b/src/Document/Styles/Offset.php
@@ -29,6 +29,20 @@ class Offset extends Base {
   protected $y;
 
   /**
+   * Implements __construct().
+   *
+   * @param int $x
+   *   X offset.
+   *
+   * @param int $y
+   *   Y offset.
+   */
+  public function __construct($x, $y) {
+    $this->setX($x);
+    $this->setY($y);
+  }
+
+  /**
    * Gets x
    *
    * @return float

--- a/src/Document/Styles/ShadowStyle.php
+++ b/src/Document/Styles/ShadowStyle.php
@@ -154,7 +154,7 @@ class ShadowStyle extends Base {
    * Validates the opacity attribute.
    */
   protected function validateOpacity($value) {
-    if (is_numeric($value) && ($value < 0 || $value > 100)) {
+    if (!is_numeric($value) || $value < 0 || $value > 100) {
       $this->triggerError('opacity is not valid');
       return FALSE;
     }
@@ -165,7 +165,7 @@ class ShadowStyle extends Base {
    * Validates the radius attribute.
    */
   protected function validateRadius($value) {
-    if (is_numeric($value) && ($value < 0 || $value > 100)) {
+    if (!is_numeric($value) || $value < 0 || $value > 100) {
       $this->triggerError('radius is not valid');
       return FALSE;
     }

--- a/src/Document/Styles/ShadowStyle.php
+++ b/src/Document/Styles/ShadowStyle.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * @file
+ * An Apple News Document Shadow style.
+ */
+
+namespace ChapterThree\AppleNewsAPI\Document\Styles;
+
+use ChapterThree\AppleNewsAPI\Document\Base;
+
+/**
+ * An Apple News Document ShadowStyle.
+ */
+class ShadowStyle extends Base {
+
+  protected $color;
+  protected $radius;
+  protected $opacity;
+  protected $offset;
+
+  /**
+   * Define optional properties.
+   */
+  protected function optional() {
+    return array_merge(parent::optional(), array(
+      'opacity',
+      'offset',
+    ));
+  }
+
+  /**
+   * Getter for color.
+   */
+  public function getColor() {
+    return $this->color;
+  }
+
+  /**
+   * Setter for color.
+   *
+   * @param string $value
+   *   Color.
+   *
+   * @return $this
+   */
+  public function setColor($value) {
+    if ($this->validateColor($value)) {
+      $this->color = $value;
+    }
+    return $this;
+  }
+
+  /**
+   * Getter for radius.
+   */
+  public function getRadius() {
+    return $this->radius;
+  }
+
+  /**
+   * Setter for radius.
+   *
+   * @param int $value
+   *   Width.
+   *
+   * @return $this
+   */
+  public function setRadius($value) {
+    if ($this->validateRadius($value)) {
+      $this->radius = $value;
+    }
+    return $this;
+  }
+
+  /**
+   * Getter for opacity.
+   */
+  public function getOpacity() {
+    return $this->opacity;
+  }
+
+  /**
+   * Setter for opacity.
+   *
+   * @param string $value
+   *   Opacity.
+   *
+   * @return $this
+   */
+  public function setOpacity($value) {
+    if ($this->validateOpacity($value)) {
+      $this->style = $value;
+    }
+    return $this;
+  }
+
+  /**
+   * Getter for Offset.
+   *
+   * @return Offset
+   */
+  public function getOffset() {
+    return $this->offset;
+  }
+
+  /**
+   * Setter for Offset
+   *
+   * @param Offset $offset
+   */
+  public function setOffset(Offset $offset) {
+    $this->offset = $offset;
+  }
+
+  /**
+   * Implements JsonSerializable::jsonSerialize().
+   */
+  public function jsonSerialize() {
+    $valid = (!isset($this->color) ||
+      $this->validateColor($this->color));
+    if (!$valid) {
+      return NULL;
+    }
+    return parent::jsonSerialize();
+  }
+
+  /**
+   * Validates the color attribute.
+   */
+  protected function validateColor($value) {
+    if (!$this->isHexColor($value)) {
+      $this->triggerError('color is not valid');
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * Validates the opacity attribute.
+   */
+  protected function validateOpacity($value) {
+    return $this->validateRadius($value);
+  }
+
+  /**
+   * Validates the radius attribute.
+   */
+  protected function validateRadius($value) {
+    if (is_numeric($value) && ($value < 0 || $value > 100)) {
+      $this->triggerError('radius is not valid');
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+}

--- a/src/Document/Styles/ShadowStyle.php
+++ b/src/Document/Styles/ShadowStyle.php
@@ -154,7 +154,11 @@ class ShadowStyle extends Base {
    * Validates the opacity attribute.
    */
   protected function validateOpacity($value) {
-    return $this->validateRadius($value);
+    if (is_numeric($value) && ($value < 0 || $value > 100)) {
+      $this->triggerError('opacity is not valid');
+      return FALSE;
+    }
+    return TRUE;
   }
 
   /**

--- a/src/Document/Styles/ShadowStyle.php
+++ b/src/Document/Styles/ShadowStyle.php
@@ -30,6 +30,20 @@ class ShadowStyle extends Base {
   }
 
   /**
+   * Implements __construct().
+   *
+   * @param string $color
+   *   Color HEX.
+   *
+   * @param int $radius
+   *   Radius.
+   */
+  public function __construct($color, $radius) {
+    $this->setColor($color);
+    $this->setRadius($radius);
+  }
+
+  /**
    * Getter for color.
    */
   public function getColor() {

--- a/src/Document/Styles/ShadowStyle.php
+++ b/src/Document/Styles/ShadowStyle.php
@@ -104,7 +104,7 @@ class ShadowStyle extends Base {
    */
   public function setOpacity($value) {
     if ($this->validateOpacity($value)) {
-      $this->style = $value;
+      $this->opacity = $value;
     }
     return $this;
   }

--- a/src/Document/Styles/TextStyle.php
+++ b/src/Document/Styles/TextStyle.php
@@ -18,12 +18,14 @@ class TextStyle extends Base {
   protected $fontName;
   protected $fontSize;
   protected $textColor;
+  protected $textShadow;
   protected $textTransform;
   protected $underline;
   protected $strikethrough;
   protected $backgroundColor;
   protected $verticalAlignment;
   protected $tracking;
+  protected $stroke;
 
   /**
    * Define optional properties.
@@ -33,9 +35,11 @@ class TextStyle extends Base {
       'fontName',
       'fontSize',
       'textColor',
+      'textShadow',
       'textTransform',
       'underline',
       'strikethrough',
+      'stroke',
       'backgroundColor',
       'verticalAlignment',
       'tracking',
@@ -102,6 +106,24 @@ class TextStyle extends Base {
       $this->textColor = $value;
     }
     return $this;
+  }
+
+  /**
+   * Getter for shadow style.
+   *
+   * @return ShadowStyle
+   */
+  public function getTextShadow() {
+    return $this->textShadow;
+  }
+
+  /**
+   * Setter for shadow style.
+   *
+   * @param ShadowStyle $textShadow
+   */
+  public function setTextShadow(ShadowStyle $textShadow) {
+    $this->textShadow = $textShadow;
   }
 
   /**
@@ -174,6 +196,24 @@ class TextStyle extends Base {
       $this->strikethrough = $value;
     }
     return $this;
+  }
+
+  /**
+   * Getter for stroke style.
+   *
+   * @return StrokeStyle
+   */
+  public function getStroke() {
+    return $this->stroke;
+  }
+
+  /**
+   * Setter for stroke style.
+   *
+   * @param StrokeStyle $stroke
+   */
+  public function setStroke(StrokeStyle $stroke) {
+    $this->stroke = $stroke;
   }
 
   /**

--- a/tests/Document/Styles/OffsetTest.php
+++ b/tests/Document/Styles/OffsetTest.php
@@ -17,21 +17,14 @@ class OffsetTest extends PHPUnit_Framework_TestCase {
    */
   public function testSetters() {
 
-    $obj = new Offset();
-
-    $json = '{}';
-    $this->assertEquals($json, $obj->json());
-
-    // Test Validation.
-    @$obj->setX('asdf');
-    $this->assertEquals($json, $obj->json());
-    @$obj->setY('asdf');
-    $this->assertEquals($json, $obj->json());
-
     $json = '{"x":50,"y":-50}';
 
-    $obj->setX('50');
-    $obj->setY('-50');
+    $obj = new Offset(50, -50);
+    $this->assertJsonStringEqualsJsonString($json, $obj->json());
+
+    $obj->setX('asdf');
+    $this->assertJsonStringEqualsJsonString($json, $obj->json());
+    $obj->setY('asdf');
     $this->assertJsonStringEqualsJsonString($json, $obj->json());
 
   }

--- a/tests/Document/Styles/OffsetTest.php
+++ b/tests/Document/Styles/OffsetTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Tests for ChapterThree\AppleNewsAPI\Document\Styles\OffsetTest.
+ */
+
+use ChapterThree\AppleNewsAPI\Document\Styles\Offset;
+
+/**
+ * Tests for the OffsetTest class.
+ */
+class OffsetTest extends PHPUnit_Framework_TestCase {
+
+  /**
+   * Setting properties and outputting json.
+   */
+  public function testSetters() {
+
+    $obj = new Offset();
+
+    $json = '{}';
+    $this->assertEquals($json, $obj->json());
+
+    // Test Validation.
+    @$obj->setX('asdf');
+    $this->assertEquals($json, $obj->json());
+    @$obj->setY('asdf');
+    $this->assertEquals($json, $obj->json());
+
+    $json = '{"x":50,"y":-50}';
+
+    $obj->setX('50');
+    $obj->setY('-50');
+    $this->assertJsonStringEqualsJsonString($json, $obj->json());
+
+  }
+
+}

--- a/tests/Document/Styles/ShadowStyleTest.php
+++ b/tests/Document/Styles/ShadowStyleTest.php
@@ -18,15 +18,13 @@ class ShadowStyleTest extends PHPUnit_Framework_TestCase {
    */
   public function testSetters() {
 
-    $obj = new ShadowStyle();
+    $obj = new ShadowStyle('#00000', 50);
 
-    $json = '{}';
+    $json = '{"color":"#000000","radius":50}';
     $this->assertEquals($json, $obj->json());
 
     // Test Validation.
     @$obj->setColor('000000');
-    $this->assertEquals($json, $obj->json());
-    @$obj->setColor('#00000');
     $this->assertEquals($json, $obj->json());
     @$obj->setColor('blue');
     $this->assertEquals($json, $obj->json());
@@ -41,15 +39,13 @@ class ShadowStyleTest extends PHPUnit_Framework_TestCase {
     @$obj->setOpacity('asdf');
     $this->assertEquals($json, $obj->json());
 
-    @$obj->setOffset(new Offset());
-    $this->assertEquals('{"offset":{}}', $obj->json());
-
     // Optional properties.
-    $json = '{"color":"#FFC800","radius":50,"opacity":50,"offset":{}}';
+    $json = '{"color":"#FFC800","radius":50,"opacity":50,"offset":{"x":50,"y":50}}';
 
-    $obj->setColor('#FFC800');
-    $obj->setRadius(50);
-    $obj->setOpacity(50);
+    @$obj->setColor('#FFC800');
+    @$obj->setRadius(50);
+    @$obj->setOpacity(50);
+    @$obj->setOffset(new Offset(50, 50));
     $this->assertJsonStringEqualsJsonString($json, $obj->json());
 
   }

--- a/tests/Document/Styles/ShadowStyleTest.php
+++ b/tests/Document/Styles/ShadowStyleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @file
+ * Tests for ChapterThree\AppleNewsAPI\Document\Styles\ShadowStyle.
+ */
+
+use ChapterThree\AppleNewsAPI\Document\Styles\Offset;
+use ChapterThree\AppleNewsAPI\Document\Styles\ShadowStyle;
+
+/**
+ * Tests for the ShadowStyleTest class.
+ */
+class ShadowStyleTest extends PHPUnit_Framework_TestCase {
+
+  /**
+   * Setting properties and outputting json.
+   */
+  public function testSetters() {
+
+    $obj = new ShadowStyle();
+
+    $json = '{}';
+    $this->assertEquals($json, $obj->json());
+
+    // Test Validation.
+    @$obj->setColor('000000');
+    $this->assertEquals($json, $obj->json());
+    @$obj->setColor('#00000');
+    $this->assertEquals($json, $obj->json());
+    @$obj->setColor('blue');
+    $this->assertEquals($json, $obj->json());
+
+    @$obj->setRadius(1000);
+    $this->assertEquals($json, $obj->json());
+    @$obj->setRadius('asdf');
+    $this->assertEquals($json, $obj->json());
+
+    @$obj->setOpacity(1000);
+    $this->assertEquals($json, $obj->json());
+    @$obj->setOpacity('asdf');
+    $this->assertEquals($json, $obj->json());
+
+    @$obj->setOffset(new Offset());
+    $this->assertEquals('{"offset":{}}', $obj->json());
+
+    // Optional properties.
+    $json = '{"color":"#FFC800","radius":50,"opacity":50,"offset":{}}';
+
+    $obj->setColor('#FFC800');
+    $obj->setRadius(50);
+    $obj->setOpacity(50);
+    $this->assertJsonStringEqualsJsonString($json, $obj->json());
+
+  }
+
+}

--- a/tests/Document/Styles/ShadowStyleTest.php
+++ b/tests/Document/Styles/ShadowStyleTest.php
@@ -18,7 +18,7 @@ class ShadowStyleTest extends PHPUnit_Framework_TestCase {
    */
   public function testSetters() {
 
-    $obj = new ShadowStyle('#00000', 50);
+    $obj = new ShadowStyle('#000000', 50);
 
     $json = '{"color":"#000000","radius":50}';
     $this->assertEquals($json, $obj->json());


### PR DESCRIPTION
Hi, I've created an extension for the API to include the [textShadow](https://developer.apple.com/library/ios/documentation/General/Conceptual/Apple_News_Format_Ref/Shadow.html#//apple_ref/doc/uid/TP40015408-CH90-SW1) component and the [Offset](https://developer.apple.com/library/ios/documentation/General/Conceptual/Apple_News_Format_Ref/Offset.html#//apple_ref/doc/uid/TP40015408-CH92-SW1) component available in the AppleNews api.