### PR TITLE
Updating to TLS 1.2 per Apple requirements

### DIFF
--- a/src/PublisherAPI/Curl.php
+++ b/src/PublisherAPI/Curl.php
@@ -238,6 +238,10 @@ class Curl extends Base {
         'Authorization'   => $this->auth($string)
       ]
     );
+
+    // Set to use TLS 1.2
+    $this->client->setOpt(CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+
     // Send POST request.
     return $this->request($contents);
   }


### PR DESCRIPTION
Apple has reached out to our organization and requested that we switch to 1.2 of TLS