### PR TITLE
Add extra TextStyle and ComponentTextStyle properties

### DIFF
--- a/src/Document/Styles/ComponentTextStyle.php
+++ b/src/Document/Styles/ComponentTextStyle.php
@@ -17,6 +17,11 @@ class ComponentTextStyle extends TextStyle {
   protected $dropCapStyle;
   protected $hyphenation;
   protected $linkStyle;
+  protected $firstLineIndent;
+  protected $fontScaling;
+  protected $hangingPunctuation;
+  protected $paragraphSpacingAfter;
+  protected $paragraphSpacingBefore;
 
   /**
    * Define optional properties.
@@ -28,6 +33,11 @@ class ComponentTextStyle extends TextStyle {
       'dropCapStyle',
       'hyphenation',
       'linkStyle',
+      'firstLineIndent',
+      'fontScaling',
+      'hangingPunctuation',
+      'paragraphSpacingAfter',
+      'paragraphSpacingBefore',
     ));
   }
 
@@ -130,6 +140,106 @@ class ComponentTextStyle extends TextStyle {
    */
   public function setHyphenation($value) {
     $this->hyphenation = $value;
+    return $this;
+  }
+
+  /**
+   * Getter for firstLineIndent.
+   */
+  public function getFirstLineIndent() {
+    return $this->firstLineIndent;
+  }
+
+  /**
+   * Setter for firstLineIndent.
+   *
+   * @param int $value
+   *   firstLineIndent.
+   *
+   * @return $this
+   */
+  public function setFirstLineIndent($value) {
+    $this->firstLineIndent = $value;
+    return $this;
+  }
+      
+  /**
+   * Getter for fontScaling.
+   */
+  public function getFontScaling() {
+    return $this->fontScaling;
+  }
+
+  /**
+   * Setter for fontScaling.
+   *
+   * @param bool $value
+   *   fontScaling.
+   *
+   * @return $this
+   */
+  public function setFontScaling($value) {
+    $this->fontScaling = $value;
+    return $this;
+  }
+
+  /**
+   * Getter for hangingPunctuation.
+   */
+  public function getHangingPunctuation() {
+    return $this->hangingPunctuation;
+  }
+
+  /**
+   * Setter for hangingPunctuation.
+   *
+   * @param bool $value
+   *   hangingPunctuation.
+   *
+   * @return $this
+   */
+  public function setHangingPunctuation($value) {
+    $this->hangingPunctuation = $value;
+    return $this;
+  }
+
+  /**
+   * Getter for paragraphSpacingAfter.
+   */
+  public function getParagraphSpacingAfter() {
+    return $this->paragraphSpacingAfter;
+  }
+
+  /**
+   * Setter for paragraphSpacingAfter.
+   *
+   * @param int $value
+   *   paragraphSpacingAfter.
+   *
+   * @return $this
+   */
+  public function setParagraphSpacingAfter($value) {
+    $this->paragraphSpacingAfter = $value;
+    return $this;
+  }
+      
+  /**
+   * Getter for paragraphSpacingBefore.
+   */
+  public function getParagraphSpacingBefore() {
+    return $this->paragraphSpacingBefore;
+  }
+
+  /**
+   * Setter for paragraphSpacingBefore.
+   *
+   * @param int $value
+   *   paragraphSpacingBefore.
+   *
+   * @return $this
+   */
+  public function setParagraphSpacingBefore($value) {
+    $this->paragraphSpacingBefore = $value;
     return $this;
   }
 

--- a/src/Document/Styles/ComponentTextStyle.php
+++ b/src/Document/Styles/ComponentTextStyle.php
@@ -113,13 +113,26 @@ class ComponentTextStyle extends TextStyle {
   /**
    * Setter for linkStyle.
    *
-   * @param \ChapterThree\AppleNewsAPI\Document\Styles\TextStyle $value
+   * @param \ChapterThree\AppleNewsAPI\Document\Styles\TextStyle | array $value
    *   LinkStyle.
    *
    * @return $this
    */
-  public function setLinkStyle(TextStyle $value) {
-    $this->linkStyle = $value;
+  public function setLinkStyle($value) {
+    if (is_object($value) && $value instanceof TextStyle) {
+      $this->linkStyle = $value;
+    } elseif (is_array($value)) {
+      $object = new TextStyle();
+      foreach ($value as $field => $v) {
+        $method = 'set' . ucfirst($field);
+        if ($v && method_exists($object, $method)) {
+          $object->{$method}($v);
+        }
+      }
+      $this->linkStyle = $object;
+    } else {
+      $this->triggerError('linkStyle is not array or object of class TextStyle');
+    }
     return $this;
   }
 

--- a/src/Document/Styles/TextStyle.php
+++ b/src/Document/Styles/TextStyle.php
@@ -18,6 +18,9 @@ class TextStyle extends Base {
   protected $fontFamily;
   protected $fontName;
   protected $fontSize;
+  protected $fontStyle;
+  protected $fontWeight;
+  protected $fontWidth;
   protected $textColor;
   protected $textShadow;
   protected $textTransform;
@@ -36,6 +39,9 @@ class TextStyle extends Base {
       'fontFamily',
       'fontName',
       'fontSize',
+      'fontStyle',
+      'fontWeight',
+      'fontWidth',
       'textColor',
       'textShadow',
       'textTransform',
@@ -105,6 +111,67 @@ class TextStyle extends Base {
    */
   public function setFontSize($value) {
     $this->fontSize = $value;
+    return $this;
+  }
+
+  /**
+   * Getter for fontStyle.
+   */
+  public function getFontStyle() {
+    return $this->fontStyle;
+  }
+
+  /**
+   * Setter for fontStyle.
+   *
+   * @param string $value
+   *   fontStyle.
+   *
+   * @return $this
+   */
+  public function setFontStyle($value) {
+    $this->fontStyle = (string) $value;
+    return $this;
+  }
+
+  /**
+   * Getter for fontWeight.
+   */
+  public function getFontWeight() {
+    return $this->fontWeight;
+  }
+
+  /**
+   * Setter for fontWeight.
+   *
+   * @param string $value
+   *   fontWeight.
+   *
+   * @return $this
+   */
+  public function setFontWeight($value) {
+    $this->fontWeight = (string) $value;
+    return $this;
+  }
+
+
+  /**
+   * Getter for fontWidth.
+   */
+  public function getfontWidth() {
+    return $this->fontWidth;
+  }
+
+  /**
+   * Setter for fontWidth.
+   *
+   * @param string $value
+   *   fontWidth.
+   *
+   * @return $this
+   */
+  public function setfontWidth($value) {
+    $this->fontWidth = (string) $value;
     return $this;
   }
 

--- a/src/Document/Styles/TextStyle.php
+++ b/src/Document/Styles/TextStyle.php
@@ -144,13 +144,13 @@ class TextStyle extends Base {
   /**
    * Setter for fontWeight.
    *
-   * @param string $value
+   * @param int|string $value
    *   fontWeight.
    *
    * @return $this
    */
   public function setFontWeight($value) {
-    $this->fontWeight = (string) $value;
+    $this->fontWeight = $value;
     return $this;
   }
 

--- a/src/Document/Styles/TextStyle.php
+++ b/src/Document/Styles/TextStyle.php
@@ -15,6 +15,7 @@ use ChapterThree\AppleNewsAPI\Document\Styles\TextStrokeStyle;
  */
 class TextStyle extends Base {
 
+  protected $fontFamily;
   protected $fontName;
   protected $fontSize;
   protected $textColor;
@@ -32,6 +33,7 @@ class TextStyle extends Base {
    */
   protected function optional() {
     return array_merge(parent::optional(), array(
+      'fontFamily',
       'fontName',
       'fontSize',
       'textColor',
@@ -44,6 +46,26 @@ class TextStyle extends Base {
       'verticalAlignment',
       'tracking',
     ));
+  }
+
+  /**
+   * Getter for fontFamily.
+   */
+  public function getFontFamily() {
+    return $this->fontFamily;
+  }
+
+  /**
+   * Setter for fontFamily.
+   *
+   * @param string $value
+   *   FontFamily.
+   *
+   * @return $this
+   */
+  public function setFontFamily($value) {
+    $this->fontFamily = (string) $value;
+    return $this;
   }
 
   /**


### PR DESCRIPTION
These changes add support for a number of additional TextStyle and ComponentTextStyle properties:

Extra TextStyle properties:

- fontFamily
- fontWeight
- fontStyle
- fontWidth

Extra ComponentTextStyle properties:

- firstLineIndent
- fontScalng
- hangingPunctuation
- paragraphSpacingAfter
- paragraphSpacingBefore

The TextStyle::fontWeight property is allowed to be a string or an integer, so that it can be set to a named font weight (e.g. "medium") or a numeric one (e.g. 500). (Applenews doesnt allow numeric font weights to be supplied as strings - so "500" is not valid.) 

The ComponentTextStyle::linkStyle property can now optionally be set using an array, which makes things easier when creating a ComponentTextStyle object.
