### PR TITLE
suppress deprecation message

### DIFF
--- a/src/Document/Base.php
+++ b/src/Document/Base.php
@@ -15,6 +15,7 @@ abstract class Base implements \JsonSerializable {
   /**
    * Implements JsonSerializable::jsonSerialize().
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     // Define empty attribute values.
     // @see http://php.net/manual/en/language.types.boolean.php#language.types.boolean.casting


### PR DESCRIPTION
Suppresses deprecation message 
`Deprecated function: Return type of ChapterThree\AppleNewsAPI\Document\Base::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include()`